### PR TITLE
Simplify archive load

### DIFF
--- a/middleware/loadArchive.js
+++ b/middleware/loadArchive.js
@@ -1,14 +1,16 @@
-import { startLoadArchive, finishedLoadArchive, setLoadErrorInSettings } from '../actions/index'
-import loadUsers from './loadUsers'
-import loadChannels from './loadChannels'
+import { startLoadArchive, finishedLoadArchive, setLoadErrorInSettings, setArchiveDisplayPath } from '../actions/index'
+import loadUsers, { clearUsers }  from './loadUsers'
+import loadChannels, { clearChannels } from './loadChannels'
+import { clearMessageGroups } from './loadMessages'
 import { doesArchiveExist } from '../util/loadArchives'
 
 export default (store, path) => {
 	const originalPath = store.getState().archive.localPath
-	if (originalPath == path)
-		return
 
-	store.dispatch(startLoadArchive(path))
+	store.dispatch(setArchiveDisplayPath(path))
+	store.dispatch(startLoadArchive())
+
+	clearMessageGroups(store)
 
 	if (doesArchiveExist(path))
 	{
@@ -19,7 +21,9 @@ export default (store, path) => {
 	}
 	else
 	{
+		clearUsers(store)
+		clearChannels(store)
 		store.dispatch(setLoadErrorInSettings('Unable to find archive at: ' + path))
-		store.dispatch(finishedLoadArchive(originalPath))
+		store.dispatch(finishedLoadArchive(undefined))
 	}
 }

--- a/middleware/loadChannel.js
+++ b/middleware/loadChannel.js
@@ -17,3 +17,7 @@ export default (store, channelName) => {
 	store.dispatch(finishedLoadMessageGroups(dailyArchivesNames))
 	loadMessages(store, [getLastOrEmpty(dailyArchivesNames)])
 }
+
+export const clearChannel = (store) => {
+	
+}

--- a/middleware/loadChannels.js
+++ b/middleware/loadChannels.js
@@ -7,3 +7,8 @@ export default (store, path) => {
 	const channelsInfo = getChannelsAsJson(path);
 	store.dispatch(finishedLoadChannels(channelsInfo))
 }
+
+export const clearChannels = (store) => {
+	store.dispatch(startLoadChannels())
+	store.dispatch(finishedLoadChannels([]))	
+}

--- a/middleware/loadMessages.js
+++ b/middleware/loadMessages.js
@@ -2,6 +2,7 @@ import { defaultSlackArchivePath } from '../util/globalPaths'
 import { makePath } from '../util/paths'
 import { getMessagesFromDailyArchive } from '../util/loadArchives'
 import { startLoadMessages, finishedLoadMessages } from '../actions/index'
+import { startLoadMessageGroups, finishedLoadMessageGroups } from '../actions/index'
 
 export default (store, messageGroupNames) => {
 	console.log('Load messages for:', messageGroupNames)
@@ -24,4 +25,10 @@ export const loadMessagesForGroup = (store, messageGroupName) => {
 		const messages = getMessagesFromDailyArchive(currentDailyArchivePath)
 		store.dispatch(finishedLoadMessages(messageGroupName, messages))
 	}
+}
+
+export const clearMessageGroups = (store) =>
+{
+	store.dispatch(startLoadMessageGroups())	
+	store.dispatch(finishedLoadMessageGroups([]))
 }

--- a/middleware/loadUsers.js
+++ b/middleware/loadUsers.js
@@ -6,3 +6,9 @@ export default (store, path) => {
 	const usersInfo = getUsersAsJson(path);
 	store.dispatch(finishedLoadUsers(usersInfo))
 }
+
+export const clearUsers = (store) =>
+{
+	store.dispatch(startLoadUsers())	
+	store.dispatch(finishedLoadUsers([]))
+}

--- a/reducers/archive.js
+++ b/reducers/archive.js
@@ -1,11 +1,9 @@
 export default (state = defaultState, action) => {
   switch (action.type) {
     case 'START_LOAD_ARCHIVE':
-      return { ...state, isLoading: true }
+      return { ...state, isLoading: true, localPath: undefined }
     case 'FINISHED_LOAD_ARCHIVE':
-      return action.path === undefined
-        ? defaultState
-        : { isLoading: false, displayPath: '', displayPath: action.path, localPath: action.path }
+      return { ...state, localPath: action.path }
     case 'SET_DISPLAY_ARCHIVE_PATH':
        return {...state, displayPath: action.path }
     default:

--- a/reducers/rootReducer.js
+++ b/reducers/rootReducer.js
@@ -1,6 +1,5 @@
 import archive from './archive'
 import channels from './channels'
-import messages from './messages'
 import settings from './settings'
 import users from './users'
 import messageGroups from './messageGroups'

--- a/reducers/settings.js
+++ b/reducers/settings.js
@@ -1,7 +1,7 @@
 export default (state = {hiddenUi: true, loadArchiveErrorMsg: undefined}, action) => {
   switch (action.type) {
     case 'TOGGLE_SETTINGS_UI':
-      return { hiddenUi: !state.hiddenUi, loadArchiveErrorMsg: undefined }
+      return {...state, hiddenUi: !state.hiddenUi }
     case 'SET_ARCHIVE_LOAD_ERROR_IN_SETTINGS':
       return {...state, loadArchiveErrorMsg: action.msg}
      default:

--- a/tests/archive.test.js
+++ b/tests/archive.test.js
@@ -9,29 +9,13 @@ const defaultState = 	{
 
 test('default archive state', () => {expect(archive(undefined, {type: undefined})).toEqual(defaultState)})
 
-test('start loading archive only sets loading state to true', () => {
-	expect(archive(defaultState, startLoadArchive())).toEqual({...defaultState, isLoading: true})
+test('start loading archive sets loading state to true and clears localPath', () => {
+	expect(archive(defaultState, startLoadArchive())).toEqual({...defaultState, isLoading: true, localPath: undefined})
 })
 
-test('finished loading archive sets loading state to false', () => {
-	expect(archive(undefined, finishedLoadArchive('any path')).isLoading).toEqual(false)
-	expect(archive(undefined, finishedLoadArchive('any path', 'any error')).isLoading).toEqual(false)
-})
-
-test('finished loading archive sets paths', () => {
-	const newState = archive(undefined, finishedLoadArchive('c'))
-	expect(newState.localPath).toEqual('c')
-	expect(newState.displayPath).toEqual('c')
-})
-
-test('finished loading archive sets paths', () => {
-	const newState = archive(undefined, finishedLoadArchive('c'))
-	expect(newState.localPath).toEqual('c')
-	expect(newState.displayPath).toEqual('c')
-})
-
-test('finished loading archive of undefined path sets default state', () => {
-	expect(archive(defaultState, finishedLoadArchive(undefined))).toEqual(defaultState)
+test('finished loading archive sets loading state to false and sets localPath', () => {
+	expect(archive(defaultState, finishedLoadArchive('a path'))).toEqual({...defaultState, isLoading: false, localPath: 'a path'})
+	expect(archive({...defaultState, localPath: 'old'}, finishedLoadArchive(undefined))).toEqual({...defaultState, isLoading: false, localPath: undefined})
 })
 
 test('set display path only sets display path', () => {

--- a/tests/settings.test.js
+++ b/tests/settings.test.js
@@ -15,8 +15,8 @@ test('toggleSettingsUi flips hiddenUi', () => {
 	expect(settings({hiddenUi: false}, toggleSettingsUi())).toEqual({hiddenUi: true})
 })
 
-test('toggleSettingsUi clears error msg', () => {
-	expect(settings({loadArchiveErrorMsg: 'hello'}, toggleSettingsUi()).loadArchiveErrorMsg).toEqual(undefined)
+test('toggleSettingsUi doesnt change error msg', () => {
+	expect(settings({loadArchiveErrorMsg: 'hello'}, toggleSettingsUi()).loadArchiveErrorMsg).toEqual('hello')
 })
 
 test('setLoadErrorInSettings sets error msg', () => {


### PR DESCRIPTION
make archive simpler - display path never changes, start loading clears localPath and current messages, finish loading sets localPath